### PR TITLE
Improve extra events support through scripts etc.

### DIFF
--- a/vsCommandEvent/Actions/ActionEnvCommand.cs
+++ b/vsCommandEvent/Actions/ActionEnvCommand.cs
@@ -69,7 +69,7 @@ namespace net.r_eg.vsCE.Actions
                 object cout = c.CustomOut;
 
                 try {
-                    cmd.Env.raise(c.Guid, c.Id, ref cin, ref cout);
+                    cmd.Env.raise(c.Guid, c.Id, cin, cout);
                 }
                 catch(Exception ex)
                 {

--- a/vsCommandEvent/Actions/Binder.cs
+++ b/vsCommandEvent/Actions/Binder.cs
@@ -217,25 +217,17 @@ namespace net.r_eg.vsCE.Actions
             foreach(IFilter f in item.Filters)
             {
                 if(!f.Pre && !f.Post) continue;
-                if((f.Pre && !pre) && (f.Post && pre)) continue;
+                if((pre && !f.Pre) || (!pre && !f.Post)) continue;
 
                 if(f.Id != id || !f.Guid.CompareGuids(guid)) continue;
 
                 if(f.IgnoreCustomIn && f.IgnoreCustomOut) return f;
 
-                bool fin = (f.IgnoreCustomIn || 
-                (
-                    (f.CustomIn != null && f.CustomIn.EqualsMixedObjects(customIn))
-                        || customIn.IsNullOrEmptyString()
-                ));
-
-                bool fout = (f.IgnoreCustomOut ||
-                (
-                    (f.CustomOut != null && f.CustomOut.EqualsMixedObjects(customOut))
-                        || customOut.IsNullOrEmptyString()
-                ));
-
-                if(fin && fout) return f;
+                if((f.IgnoreCustomIn || f.CustomIn.EqualsMixedObjects(customIn, nullAndEmptyStr: true)) 
+                    && (f.IgnoreCustomOut || f.CustomOut.EqualsMixedObjects(customOut, nullAndEmptyStr: true)))
+                {
+                    return f;
+                }
             }
             return null;
         }

--- a/vsCommandEvent/DteEnv.cs
+++ b/vsCommandEvent/DteEnv.cs
@@ -39,8 +39,8 @@ namespace net.r_eg.vsCE
         public void Execute(string cmd)
             => dteo.Value.exec(new string[] { cmd }, false);
 
-        public void Raise(string guid, int id, ref object customIn, ref object customOut)
-            => env.raise(guid, id, ref customIn, ref customOut);
+        public void Raise(string guid, int id, object customIn, object customOut)
+            => env.raise(guid, id, customIn, customOut);
 
         public void Dispose() => DetachCommandEvents();
 

--- a/vsCommandEvent/Environment.cs
+++ b/vsCommandEvent/Environment.cs
@@ -350,6 +350,11 @@ namespace net.r_eg.vsCE
         /// <param name="customOut">Custom output parameters.</param>
         public void raise(string guid, int id, object customIn, object customOut)
         {
+            if(AggregatedEventsEnvDte.FindExtra(guid, out string at))
+            {
+                Log.Info($"Ignored raise {guid} #{id} due to source {at}");
+                return;
+            }
             ((EnvDTE.DTE)Dte2).Commands.Raise(guid, id, customIn, customOut);
         }
 

--- a/vsCommandEvent/Environment.cs
+++ b/vsCommandEvent/Environment.cs
@@ -348,9 +348,9 @@ namespace net.r_eg.vsCE
         /// <param name="id">The command ID.</param>
         /// <param name="customIn">Custom input parameters.</param>
         /// <param name="customOut">Custom output parameters.</param>
-        public void raise(string guid, int id, ref object customIn, ref object customOut)
+        public void raise(string guid, int id, object customIn, object customOut)
         {
-            ((EnvDTE.DTE)Dte2).Commands.Raise(guid, id, ref customIn, ref customOut);
+            ((EnvDTE.DTE)Dte2).Commands.Raise(guid, id, customIn, customOut);
         }
 
         /// <param name="dte2"></param>

--- a/vsCommandEvent/Environment.cs
+++ b/vsCommandEvent/Environment.cs
@@ -365,7 +365,7 @@ namespace net.r_eg.vsCE
             Dte2        = dte2;
             this.elvl   = elvl;
 
-            AggregatedEvents = new(this);
+            AggregatedEvents = AggregatedEventsEnvDte.GetInstance(this);
 
             //TODO: ?disposing whole environment
 

--- a/vsCommandEvent/Events/AggregatedEventsEnvDte.cs
+++ b/vsCommandEvent/Events/AggregatedEventsEnvDte.cs
@@ -12,14 +12,15 @@ namespace net.r_eg.vsCE.Events
 {
     public sealed class AggregatedEventsEnvDte
     {
-        internal const string DOC_EVENTS = "{2555243A-2A69-4335-BAD6-DDE9DFFE90F2}";
+        internal const string E_DOC = "{2555243A-2A69-4335-BAD6-DDE9DFFE90F2}";
+        internal const int E_DOC_ID_OPENING = 0x100;
+        internal const int E_DOC_ID_CLOSING = 0x101;
 
         internal static readonly Dictionary<string, string> ExtraEvents = new()
         {
-            { DOC_EVENTS, "@DocumentEvents" }
+            { E_DOC, "@DocumentEvents" }
         };
 
-        /// <remarks>protects from GC</remarks>
         private readonly EnvDTE.CommandEvents cmdEvents;
         private readonly EnvDTE.DocumentEvents docEvents;
 
@@ -56,16 +57,36 @@ namespace net.r_eg.vsCE.Events
 
         private void onDocumentClosing(EnvDTE.Document doc)
         {
-            object input  = Value.From(doc?.FullName);
-            object output = Value.From(doc?.Language);
-            AfterExecute(DOC_EVENTS, 0x101, input, output);
+            if(doc == null)
+            {
+                AfterExecute(E_DOC, E_DOC_ID_CLOSING, null, null);
+                return;
+            }
+
+            AfterExecute
+            (
+                E_DOC, E_DOC_ID_CLOSING, 
+                Value.From(doc.FullName), 
+                ParamPacker.Pack
+                (
+                    "Language", doc.Language,
+                    "Saved", doc.Saved,
+                    "Kind", doc.Kind,
+                    "Type", doc.Type,
+                    "ReadOnly", doc.ReadOnly,
+                    "IndentSize", doc.IndentSize,
+                    "TabSize", doc.TabSize,
+                    "Name", doc.Name,
+                    "Path", doc.Path
+                )
+            );
         }
 
         private void onDocumentOpening(string path, bool readOnly)
         {
             object input  = path;
             object output = Value.From(readOnly);
-            AfterExecute(DOC_EVENTS, 0x100, input, output);
+            AfterExecute(E_DOC, E_DOC_ID_OPENING, input, output);
         }
     }
 }

--- a/vsCommandEvent/Events/AggregatedEventsEnvDte.cs
+++ b/vsCommandEvent/Events/AggregatedEventsEnvDte.cs
@@ -57,6 +57,9 @@ namespace net.r_eg.vsCE.Events
         private readonly EnvDTE.WindowEvents windowEvents;
         private readonly EnvDTE.DebuggerEvents dbgEvents;
 
+        private static volatile AggregatedEventsEnvDte instance;
+        private static readonly object sync = new();
+
         public delegate void BeforeExecuteEventHandler(string guid, int id, object customIn, object customOut, ref bool cancel);
 
         public delegate void AfterExecuteEventHandler(string guid, int id, object customIn, object customOut);
@@ -67,7 +70,17 @@ namespace net.r_eg.vsCE.Events
 
         internal static bool FindExtra(string guid, out string found) => ExtraEvents.TryGetValue(guid, out found);
 
-        internal AggregatedEventsEnvDte(IEnvironment env)
+        internal static AggregatedEventsEnvDte GetInstance(IEnvironment env = null)
+        {
+            if(instance != null) return instance;
+            lock(sync)
+            {
+                if(instance == null) instance = new(env);
+                return instance;
+            }
+        }
+
+        private AggregatedEventsEnvDte(IEnvironment env)
         {
             if(env?.Events == null)
             {

--- a/vsCommandEvent/Events/AggregatedEventsEnvDte.cs
+++ b/vsCommandEvent/Events/AggregatedEventsEnvDte.cs
@@ -5,7 +5,7 @@
  * See accompanying LICENSE file or visit https://github.com/3F/vsCommandEvent
 */
 
-using System;
+using System.Collections.Generic;
 using net.r_eg.SobaScript;
 
 namespace net.r_eg.vsCE.Events
@@ -13,6 +13,11 @@ namespace net.r_eg.vsCE.Events
     public sealed class AggregatedEventsEnvDte
     {
         internal const string DOC_EVENTS = "{2555243A-2A69-4335-BAD6-DDE9DFFE90F2}";
+
+        internal static readonly Dictionary<string, string> ExtraEvents = new()
+        {
+            { DOC_EVENTS, "@DocumentEvents" }
+        };
 
         /// <remarks>protects from GC</remarks>
         private readonly EnvDTE.CommandEvents cmdEvents;

--- a/vsCommandEvent/Events/AggregatedEventsEnvDte.cs
+++ b/vsCommandEvent/Events/AggregatedEventsEnvDte.cs
@@ -35,14 +35,10 @@ namespace net.r_eg.vsCE.Events
             }
 
             cmdEvents = env.Events.CommandEvents; // important! protects from GC
-            cmdEvents.BeforeExecute -= onCmdBeforeExecute;
-            cmdEvents.AfterExecute -= onCmdAfterExecute;
             cmdEvents.BeforeExecute += onCmdBeforeExecute;
             cmdEvents.AfterExecute += onCmdAfterExecute;
 
             docEvents = env.Events.DocumentEvents;
-            docEvents.DocumentOpening -= onDocumentOpening;
-            docEvents.DocumentClosing -= onDocumentClosing;
             docEvents.DocumentOpening += onDocumentOpening;
             docEvents.DocumentClosing += onDocumentClosing;
         }

--- a/vsCommandEvent/Events/AggregatedEventsEnvDte.cs
+++ b/vsCommandEvent/Events/AggregatedEventsEnvDte.cs
@@ -5,6 +5,7 @@
  * See accompanying LICENSE file or visit https://github.com/3F/vsCommandEvent
 */
 
+using System;
 using System.Collections.Generic;
 using net.r_eg.SobaScript;
 
@@ -16,23 +17,57 @@ namespace net.r_eg.vsCE.Events
         internal const int E_DOC_ID_OPENING = 0x100;
         internal const int E_DOC_ID_CLOSING = 0x101;
 
+        internal const string E_SLN = "{AD4AD581-801F-4399-B986-27FE2D308BDD}";
+        internal const int E_SLN_OPEN           = 0x100;
+        internal const int E_SLN_RENAME         = 0x101;
+        internal const int E_SLN_CLOSE_BEFORE   = 0x200;
+        internal const int E_SLN_CLOSE_AFTER    = 0x201;
+        internal const int E_SLN_CLOSE_QUERY    = 0x202;
+        internal const int E_SLN_PRJ_ADD        = 0x300;
+        internal const int E_SLN_PRJ_DEL        = 0x301;
+        internal const int E_SLN_PRJ_REN        = 0x302;
+
+        internal const string E_OW = "{600FCA14-172C-42F3-AC91-1BC5F32CF896}";
+        internal const int E_OW_ADD     = 0x100;
+        internal const int E_OW_UPD     = 0x101;
+        internal const int E_OW_CLEAR   = 0x102;
+
+        internal const string E_WND = "{69F5F698-996B-4293-9FE7-4202564FE6E5}";
+        internal const int E_WND_CREATE = 0x100;
+        internal const int E_WND_CLOSE  = 0x101;
+
+        internal const string E_DBG = "{4885535D-A7F9-46AB-A285-8E4D76F4C5B0}";
+        internal const int E_DBG_RUN    = 0x100;
+        internal const int E_DBG_BREAK  = 0x101;
+        internal const int E_DBG_DESIGN = 0x102;
+
         internal static readonly Dictionary<string, string> ExtraEvents = new()
         {
-            { E_DOC, "@DocumentEvents" }
+            { E_DOC,    "@Document" },
+            { E_OW,     "@OutputWindow" },
+            { E_SLN,    "@Solution" },
+            { E_WND,    "@Window" },
+            { E_DBG,    "@Debugger" },
         };
 
         private readonly EnvDTE.CommandEvents cmdEvents;
         private readonly EnvDTE.DocumentEvents docEvents;
+        private readonly EnvDTE.OutputWindowEvents owEvents;
+        private readonly EnvDTE.SolutionEvents slnEvents;
+        private readonly EnvDTE.WindowEvents windowEvents;
+        private readonly EnvDTE.DebuggerEvents dbgEvents;
 
         public delegate void BeforeExecuteEventHandler(string guid, int id, object customIn, object customOut, ref bool cancel);
 
         public delegate void AfterExecuteEventHandler(string guid, int id, object customIn, object customOut);
 
-        public event BeforeExecuteEventHandler BeforeExecute = delegate (string guid, int id, object customIn, object customOut, ref bool cancel) { };
+        internal event BeforeExecuteEventHandler BeforeExecute = delegate (string guid, int id, object customIn, object customOut, ref bool cancel) { };
 
-        public event AfterExecuteEventHandler AfterExecute = delegate (string guid, int id, object customIn, object customOut) { };
+        internal event AfterExecuteEventHandler AfterExecute = delegate (string guid, int id, object customIn, object customOut) { };
 
-        public AggregatedEventsEnvDte(IEnvironment env)
+        internal static bool FindExtra(string guid, out string found) => ExtraEvents.TryGetValue(guid, out found);
+
+        internal AggregatedEventsEnvDte(IEnvironment env)
         {
             if(env?.Events == null)
             {
@@ -40,20 +75,225 @@ namespace net.r_eg.vsCE.Events
                 return; //this can be for emulated DTE2 context
             }
 
+            #region Up
+
             cmdEvents = env.Events.CommandEvents; // important! protects from GC
             cmdEvents.BeforeExecute += onCmdBeforeExecute;
             cmdEvents.AfterExecute += onCmdAfterExecute;
 
+            // @Document
+
             docEvents = env.Events.DocumentEvents;
             docEvents.DocumentOpening += onDocumentOpening;
             docEvents.DocumentClosing += onDocumentClosing;
+
+            // @Solution
+
+            slnEvents = env.Events.SolutionEvents;
+            slnEvents.Opened += onSlnEventsOpened;
+            slnEvents.BeforeClosing += onSlnEventsBeforeClosing;
+            slnEvents.QueryCloseSolution += onSlnEventsQueryCloseSolution;
+            slnEvents.AfterClosing += onSlnEventsAfterClosing;
+            slnEvents.Renamed += onSlnEventsRenamed;
+            slnEvents.ProjectAdded += onSlnEventsProjectAdded;
+            slnEvents.ProjectRemoved += onSlnEventsProjectRemoved;
+            slnEvents.ProjectRenamed += onSlnEventsProjectRenamed;
+
+            // @OutputWindow
+
+            owEvents = env.Events.OutputWindowEvents;
+            owEvents.PaneAdded += onOwpAdded;
+            owEvents.PaneClearing += onOwpClearing;
+            owEvents.PaneUpdated += onOwpUpdated;
+
+            // @Window
+
+            windowEvents = env.Events.WindowEvents;
+            windowEvents.WindowClosing += onWindowClosing;
+            windowEvents.WindowCreated += onWindowCreated;
+            //windowEvents.WindowMoved += onWindowMoved;
+            //windowEvents.WindowActivated += onWindowActivated;
+
+            // @Debugger
+
+            dbgEvents = env.Events.DebuggerEvents;
+            dbgEvents.OnEnterBreakMode += onDbgEnterBreakMode;
+            dbgEvents.OnEnterDesignMode += onDbgEnterDesignMode;
+            dbgEvents.OnEnterRunMode += onDbgEnterRunMode;
+            //dbgEvents.OnContextChanged += onDbContextChanged;
+            //dbgEvents.OnExceptionNotHandled += onDbgExceptionNotHandled;
+            //dbgEvents.OnExceptionThrown += onDbgExceptionThrown;
+
+            #endregion
         }
+
+        #region @Debugger
+
+        private void onDbgEnterRunMode(EnvDTE.dbgEventReason reason) => AfterExecute(E_DBG, E_DBG_RUN, reason, null);
+
+        private void onDbgEnterDesignMode(EnvDTE.dbgEventReason reason) => AfterExecute(E_DBG, E_DBG_DESIGN, reason, null);
+
+        private void onDbgEnterBreakMode(EnvDTE.dbgEventReason reason, ref EnvDTE.dbgExecutionAction ExecutionAction)
+            => AfterExecute(E_DBG, E_DBG_BREAK, reason, ExecutionAction); //TODO: ref state
+
+        #endregion
+
+        #region @Window
+
+        private void onWindowCreated(EnvDTE.Window window) => onWindow(E_WND_CREATE, window);
+
+        private void onWindowClosing(EnvDTE.Window window) => onWindow(E_WND_CLOSE, window);
+
+        private void onWindow(int id, EnvDTE.Window window)
+        {
+            if(window == null)
+            {
+                AfterExecute(E_WND, id, null, null);
+                return;
+            }
+
+            EnvDTE.Document doc = TryGetCOMProp(() => window.Document);
+            EnvDTE.Window lnk = TryGetCOMProp(() => window.LinkedWindowFrame);
+
+            AfterExecute
+            (
+                E_WND, id,
+                TryGetCOMProp(() => window.Caption),
+                ParamPacker.Pack
+                (
+                    "Kind", TryGetCOMProp(() => window.Kind),
+                    "Type", TryGetCOMProp(() => window.Type),
+                    "Pos", PackRect(window),
+                    "WindowState", TryGetCOMProp(() => window.WindowState),
+                    "HWnd", TryGetCOMProp(() => window.HWnd),
+                    "Visible", TryGetCOMProp(() => window.Visible),
+                    "AutoHides", TryGetCOMProp(() => window.AutoHides),
+                    "IsFloating", TryGetCOMProp(() => window.IsFloating),
+                    "Linkable", TryGetCOMProp(() => window.Linkable),
+
+                    "LinkedWindowFrame.Caption", TryGetCOMProp(() => lnk?.Caption),
+                    "LinkedWindowFrame.Kind", TryGetCOMProp(() => lnk?.Kind),
+                    "LinkedWindowFrame.Type", TryGetCOMProp(() => lnk?.Type),
+                    "LinkedWindowFrame.HWnd", TryGetCOMProp(() => lnk?.HWnd),
+                    "LinkedWindowFrame.Pos", PackRect(lnk),
+
+                    "Document.Name", TryGetCOMProp(() => doc?.Name),
+                    "Document.Kind", TryGetCOMProp(() => doc?.Kind),
+                    "Document.Type", TryGetCOMProp(() => doc?.Type),
+                    "Document.Language", TryGetCOMProp(() => doc?.Language),
+                    "Document.ReadOnly", TryGetCOMProp(() => doc?.ReadOnly),
+                    "Document.Saved", TryGetCOMProp(() => doc?.Saved),
+                    "Document.IndentSize", TryGetCOMProp(() => doc?.IndentSize),
+                    "Document.TabSize", TryGetCOMProp(() => doc?.TabSize),
+                    "Document.Path", TryGetCOMProp(() => doc?.Path),
+                    "Document.FullName", TryGetCOMProp(() => doc?.FullName)
+                )
+            );
+        }
+
+        #endregion
+
+        #region @Solution
+
+        private void onSlnEventsRenamed(string oldName)
+            => AfterExecute(E_SLN, E_SLN_RENAME, oldName, null);
+
+        private void onSlnEventsQueryCloseSolution(ref bool fCancel)
+            => BeforeExecute(E_SLN, E_SLN_CLOSE_QUERY, null, null, ref fCancel);
+
+        private void onSlnEventsProjectRenamed(EnvDTE.Project project, string oldName)
+            => onSlnEventsProject(E_SLN_PRJ_REN, project, oldName);
+
+        private void onSlnEventsProjectRemoved(EnvDTE.Project project) => onSlnEventsProject(E_SLN_PRJ_DEL, project);
+
+        private void onSlnEventsProjectAdded(EnvDTE.Project project) => onSlnEventsProject(E_SLN_PRJ_ADD, project);
+
+        private void onSlnEventsProject(int id, EnvDTE.Project project, string oldName = null)
+        {
+            if(project == null)
+            {
+                AfterExecute(E_SLN, id, null, null);
+                return;
+            }
+
+            EnvDTE.Configuration cfg = TryGetCOMProp(() => project.ConfigurationManager?.ActiveConfiguration);
+            EnvDTE.CodeModel cm = TryGetCOMProp(() => project.CodeModel);
+
+            AfterExecute
+            (
+                E_SLN, id,
+                TryGetCOMProp(() => project.Name),
+                ParamPacker.Pack
+                (
+                    "OldName", oldName,
+                    "IsDirty", TryGetCOMProp(() => project.IsDirty),
+                    "Saved", TryGetCOMProp(() => project.Saved),
+                    "Kind", TryGetCOMProp(() => project.Kind),
+                    "UniqueName", TryGetCOMProp(() => project.UniqueName),
+                    "FileName", TryGetCOMProp(() => project.FileName),
+                    "FullName", TryGetCOMProp(() => project.FullName),
+
+                    "ActiveConfiguration.IsBuildable", TryGetCOMProp(() => cfg?.IsBuildable),
+                    "ActiveConfiguration.IsDeployable", TryGetCOMProp(() => cfg?.IsDeployable),
+                    "ActiveConfiguration.IsRunable", TryGetCOMProp(() => cfg?.IsRunable),
+                    "ActiveConfiguration.Name", TryGetCOMProp(() => cfg?.ConfigurationName),
+                    "ActiveConfiguration.Platform", TryGetCOMProp(() => cfg?.PlatformName),
+
+                    "CodeModel.Language", TryGetCOMProp(() => cm?.Language),
+                    "CodeModel.IsCaseSensitive", TryGetCOMProp(() => cm?.IsCaseSensitive),
+                    "CodeModel.CodeElements.Count", TryGetCOMProp(() => cm?.CodeElements.Count)
+                )
+            );
+        }
+
+        private void onSlnEventsAfterClosing() => AfterExecute(E_SLN, E_SLN_CLOSE_AFTER, null, null);
+
+        private void onSlnEventsOpened() => AfterExecute(E_SLN, E_SLN_OPEN, null, null);
+
+        private void onSlnEventsBeforeClosing() => AfterExecute(E_SLN, E_SLN_CLOSE_BEFORE, null, null);
+
+        #endregion
+
+        #region @OutputWindow
+
+        private void onOwpUpdated(EnvDTE.OutputWindowPane pPane) => onOwp(E_OW_UPD, pPane);
+
+        private void onOwpClearing(EnvDTE.OutputWindowPane pPane) => onOwp(E_OW_CLEAR, pPane);
+
+        private void onOwpAdded(EnvDTE.OutputWindowPane pPane) => onOwp(E_OW_ADD, pPane);
+
+        private void onOwp(int id, EnvDTE.OutputWindowPane pPane)
+        {
+            if(pPane == null)
+            {
+                AfterExecute(E_OW, id, null, null);
+                return;
+            }
+
+            AfterExecute
+            (
+                E_OW, id,
+                TryGetCOMProp(() => pPane.Name), 
+                ParamPacker.Pack
+                (
+                    "Guid", TryGetCOMProp(() => pPane.Guid)
+                )
+            );
+        }
+
+        #endregion
+
+        #region @Commands
 
         private void onCmdBeforeExecute(string Guid, int ID, object CustomIn, object CustomOut, ref bool CancelDefault)
             => BeforeExecute(Guid, ID, CustomIn, CustomOut, ref CancelDefault);
 
         private void onCmdAfterExecute(string Guid, int ID, object CustomIn, object CustomOut)
             => AfterExecute(Guid, ID, CustomIn, CustomOut);
+
+        #endregion
+
+        #region @Document
 
         private void onDocumentClosing(EnvDTE.Document doc)
         {
@@ -66,27 +306,42 @@ namespace net.r_eg.vsCE.Events
             AfterExecute
             (
                 E_DOC, E_DOC_ID_CLOSING, 
-                Value.From(doc.FullName), 
+                TryGetCOMProp(() => doc.FullName), 
                 ParamPacker.Pack
                 (
-                    "Language", doc.Language,
-                    "Saved", doc.Saved,
-                    "Kind", doc.Kind,
-                    "Type", doc.Type,
-                    "ReadOnly", doc.ReadOnly,
-                    "IndentSize", doc.IndentSize,
-                    "TabSize", doc.TabSize,
-                    "Name", doc.Name,
-                    "Path", doc.Path
+                    "Language", TryGetCOMProp(() => doc.Language),
+                    "Saved", TryGetCOMProp(() => doc.Saved),
+                    "Type", TryGetCOMProp(() => doc.Type),
+                    "ReadOnly", TryGetCOMProp(() => doc.ReadOnly),
+                    "IndentSize", TryGetCOMProp(() => doc.IndentSize),
+                    "TabSize", TryGetCOMProp(() => doc.TabSize),
+                    "Kind", TryGetCOMProp(() => doc.Kind),
+                    "Name", TryGetCOMProp(() => doc.Name),
+                    "Path", TryGetCOMProp(() => doc.Path)
                 )
             );
         }
 
-        private void onDocumentOpening(string path, bool readOnly)
+        private void onDocumentOpening(string path, bool readOnly) 
+            => AfterExecute(E_DOC, E_DOC_ID_OPENING, path, Value.From(readOnly));
+
+        #endregion
+
+        private static T TryGetCOMProp<T>(Func<T> cb)
         {
-            object input  = path;
-            object output = Value.From(readOnly);
-            AfterExecute(E_DOC, E_DOC_ID_OPENING, input, output);
+            try { return cb(); } catch { return default; } // COM, possible detaching/switching context etc.
+        }
+
+        internal static string PackRect(EnvDTE.Window w)
+        {
+            if(w == null) return null;
+            return ParamPacker.PackRect
+            (
+                TryGetCOMProp(() => w.Left),
+                TryGetCOMProp(() => w.Top),
+                TryGetCOMProp(() => w.Width),
+                TryGetCOMProp(() => w.Height)
+            );
         }
     }
 }

--- a/vsCommandEvent/Events/CommandEvents/Filter.cs
+++ b/vsCommandEvent/Events/CommandEvents/Filter.cs
@@ -5,87 +5,28 @@
  * See accompanying LICENSE file or visit https://github.com/3F/vsCommandEvent
 */
 
-using Newtonsoft.Json;
-
 namespace net.r_eg.vsCE.Events.CommandEvents
 {
-    /// <summary>
-    /// Filters for ICommandEvent
-    /// </summary>
     public class Filter: IFilter
     {
-        /// <summary>
-        /// For work with command ID
-        /// </summary>
-        public int Id
-        {
-            get;
-            set;
-        }
+        public int Id { get; set; }
 
-        /// <summary>
-        /// Scope by GUID
-        /// </summary>
-        public string Guid
-        {
-            get;
-            set;
-        }
+        public string Guid { get; set; }
 
-        /// <summary>
-        /// Filter by Custom input parameters
-        /// </summary>
-        public object CustomIn
-        {
-            get;
-            set;
-        }
+        public object CustomIn { get; set; }
 
-        /// <summary>
-        /// Filter by Custom output parameters
-        /// </summary>
-        public object CustomOut
-        {
-            get;
-            set;
-        }
+        public object CustomOut { get; set; }
 
-        /// <summary>
-        /// Cancel command if it's possible
-        /// </summary>
-        public bool Cancel
-        {
-            get;
-            set;
-        }
+        public bool Cancel { get; set; }
 
-        /// <summary>
-        /// Use Before executing command
-        /// </summary>
-        public bool Pre
-        {
-            get { return pre; }
-            set { pre = value; }
-        }
-        private bool pre = true;
+        public bool Pre { get; set; } = true;
 
-        /// <summary>
-        /// Use After executed command
-        /// </summary>
-        public bool Post
-        {
-            get { return post; }
-            set { post = value; }
-        }
-        private bool post = false;
+        public bool Post { get; set; }
 
-        /// <summary>
-        /// About filter
-        /// </summary>
-        public string Description
-        {
-            get;
-            set;
-        }
+        public string Description { get; set; }
+
+        public bool IgnoreCustomIn { get; set; }
+
+        public bool IgnoreCustomOut { get; set; }
     }
 }

--- a/vsCommandEvent/Events/CommandEvents/IFilter.cs
+++ b/vsCommandEvent/Events/CommandEvents/IFilter.cs
@@ -5,15 +5,11 @@
  * See accompanying LICENSE file or visit https://github.com/3F/vsCommandEvent
 */
 
-using System;
-using System.Runtime.InteropServices;
-
 namespace net.r_eg.vsCE.Events.CommandEvents
 {
     /// <summary>
     /// Specifies filters for ICommandEvent
     /// </summary>
-    [Guid("7119BA06-8F1A-4055-BA13-9ADA5850D1B7")]
     public interface IFilter
     {
         /// <summary>
@@ -52,8 +48,18 @@ namespace net.r_eg.vsCE.Events.CommandEvents
         bool Post { get; set; }
 
         /// <summary>
-        /// About filter
+        /// User note.
         /// </summary>
         string Description { get; set; }
+
+        /// <summary>
+        /// Ignore <see cref="CustomIn"/> if true.
+        /// </summary>
+        bool IgnoreCustomIn { get; set; }
+
+        /// <summary>
+        /// Ignore <see cref="CustomOut"/> if true.
+        /// </summary>
+        bool IgnoreCustomOut { get; set; }
     }
 }

--- a/vsCommandEvent/Extensions/ObjectExtension.cs
+++ b/vsCommandEvent/Extensions/ObjectExtension.cs
@@ -119,24 +119,16 @@ namespace net.r_eg.vsCE.Extensions
         /// <returns>true value if the objects are considered equal.</returns>
         public static bool EqualsMixedObjects(this object left, object right)
         {
-            if(left == null && right == null) {
-                return true;
-            }
-
-            if(left == null || right == null) {
-                return false;
-            }
-
-            if(Object.ReferenceEquals(left, right)) {
-                return true;
-            }
+            if(left == null && right == null) return true;
+            if(left == null || right == null) return false;
+            if(ReferenceEquals(left, right)) return true;
 
             if(left.GetType().IsArray && right.GetType().IsArray) {
                 return Enumerable.SequenceEqual((object[])left, (object[])right);
             }
 
             if(!left.GetType().IsArray && !right.GetType().IsArray) {
-                return Object.Equals(left, right);
+                return left.Equals(right);
             }
 
             return false;
@@ -149,7 +141,7 @@ namespace net.r_eg.vsCE.Extensions
         /// <returns>true if null or empty string, otherwise false.</returns>
         public static bool IsNullOrEmptyString(this object obj)
         {
-            return (obj == null || obj is string && (string)obj == String.Empty);
+            return (obj == null || obj is string str && str == string.Empty);
         }
 
         /// <summary>

--- a/vsCommandEvent/Extensions/ObjectExtension.cs
+++ b/vsCommandEvent/Extensions/ObjectExtension.cs
@@ -116,11 +116,20 @@ namespace net.r_eg.vsCE.Extensions
         /// </summary>
         /// <param name="left">The first object to compare.</param>
         /// <param name="right">The second object to compare.</param>
+        /// <param name="nullAndEmptyStr">Compare null or empty strings as equal if true.</param>
         /// <returns>true value if the objects are considered equal.</returns>
-        public static bool EqualsMixedObjects(this object left, object right)
+        public static bool EqualsMixedObjects(this object left, object right, bool nullAndEmptyStr = false)
         {
             if(left == null && right == null) return true;
-            if(left == null || right == null) return false;
+            if(left == null || right == null)
+            {
+                return nullAndEmptyStr 
+                        && 
+                        (
+                            (left == null && right is string rstr && rstr == string.Empty)
+                            || (right == null && left is string lstr && lstr == string.Empty)
+                        );
+            }
             if(ReferenceEquals(left, right)) return true;
 
             if(left.GetType().IsArray && right.GetType().IsArray) {

--- a/vsCommandEvent/IEnvironment.cs
+++ b/vsCommandEvent/IEnvironment.cs
@@ -132,7 +132,7 @@ namespace net.r_eg.vsCE
         /// <param name="id">The command ID.</param>
         /// <param name="customIn">Custom input parameters.</param>
         /// <param name="customOut">Custom output parameters.</param>
-        void raise(string guid, int id, ref object customIn, ref object customOut);
+        void raise(string guid, int id, object customIn, object customOut);
 
         /// <summary>
         /// To update the Project Name by default aka "StartUp Project".

--- a/vsCommandEvent/IsolatedEnv.cs
+++ b/vsCommandEvent/IsolatedEnv.cs
@@ -214,9 +214,9 @@ namespace net.r_eg.vsCE
         /// <param name="id">The command ID.</param>
         /// <param name="customIn">Custom input parameters.</param>
         /// <param name="customOut">Custom output parameters.</param>
-        public void raise(string guid, int id, ref object customIn, ref object customOut)
+        public void raise(string guid, int id, object customIn, object customOut)
         {
-            Log.Warn("Disabled for this Environment. /raise: '{0}', '{1}', '{2}', '{3}'", guid, id, customIn, customOut);
+            Log.Warn($"Disabled for this Environmen: raise('{guid}', '{id}', '{customIn}', '{customOut}')");
         }
 
         /// <summary>

--- a/vsCommandEvent/IsolatedEnv.cs
+++ b/vsCommandEvent/IsolatedEnv.cs
@@ -204,7 +204,7 @@ namespace net.r_eg.vsCE
             //    return;
             //}
 
-            Log.Warn("Disabled for this Environment. /exec: '{0}', args: '{1}'", name, args);
+            __disabled($"{name}({args})");
         }
 
         /// <summary>
@@ -216,7 +216,7 @@ namespace net.r_eg.vsCE
         /// <param name="customOut">Custom output parameters.</param>
         public void raise(string guid, int id, object customIn, object customOut)
         {
-            Log.Warn($"Disabled for this Environmen: raise('{guid}', '{id}', '{customIn}', '{customOut}')");
+            __disabled($"raise('{guid}', '{id}', '{customIn}', '{customOut}')");
         }
 
         /// <summary>

--- a/vsCommandEvent/IsolatedEnv.cs
+++ b/vsCommandEvent/IsolatedEnv.cs
@@ -250,7 +250,7 @@ namespace net.r_eg.vsCE
             SolutionFileName    = slnProperties.GetOrDefault(PropertyNames.SLN_NAME, PropertyNames.UNDEFINED);
             IsOpenedSolution    = true;
 
-            AggregatedEvents = new(this);
+            AggregatedEvents = AggregatedEventsEnvDte.GetInstance(this);
         }
 
         /// <summary>

--- a/vsCommandEvent/MainToolCommand.cs
+++ b/vsCommandEvent/MainToolCommand.cs
@@ -15,68 +15,50 @@ using System.Threading.Tasks;
 
 namespace net.r_eg.vsCE
 {
-    /// <summary>
-    /// Build / { Main App }
-    /// </summary>
     internal sealed class MainToolCommand: IDisposable
     {
         private readonly MenuCommand mcmd;
 
-        private readonly IEvLevel apievt;
-
-        private readonly IPkg pkg;
-
         private UI.WForms.EventsFrm configFrm;
 
-        public static MainToolCommand Instance
-        {
-            get;
-            private set;
-        }
+        private static volatile MainToolCommand _instance;
 
-        public void closeConfigForm()
-        {
-            UI.Util.closeTool(configFrm);
-        }
+        private static readonly object sync = new();
+
+        public static MainToolCommand Instance => _instance;
+
+        public void closeConfigForm() => UI.Util.closeTool(configFrm);
 
 #if SDK15_OR_HIGH
 
         public static async Task<MainToolCommand> InitAsync(IPkg pkg, IEvLevel evt)
         {
-            if(Instance != null) {
-                return Instance;
-            }
+            if(Instance != null) return Instance;
 
             // Switch to the main thread - the call to AddCommand in MainToolCommand's constructor requires
             // the UI thread.
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(pkg.CancellationToken);
-
-            Instance = new MainToolCommand
-            (
-                pkg,
-                await pkg.getSvcAsync(typeof(IMenuCommandService)) as OleMenuCommandService,
-                evt
-            );
-
-            return Instance;
+            
+            OleMenuCommandService svc = await pkg.getSvcAsync(typeof(IMenuCommandService)) as OleMenuCommandService;
+            lock(sync)
+            {
+                if(Instance == null) _instance = new MainToolCommand(pkg, svc, evt);
+                return Instance;
+            }
         }
 
 #else
 
         public static MainToolCommand Init(IPkg pkg, IEvLevel evt)
         {
-            if(Instance != null) {
+            if(Instance != null) return Instance;
+
+            OleMenuCommandService svc = pkg.getSvc(typeof(IMenuCommandService)) as OleMenuCommandService;
+            lock(sync)
+            {
+                if(Instance == null) _instance = new MainToolCommand(pkg, svc, evt);
                 return Instance;
             }
-
-            Instance = new MainToolCommand
-            (
-                pkg,
-                pkg.getSvc(typeof(IMenuCommandService)) as OleMenuCommandService, 
-                evt
-            );
-
-            return Instance;
         }
 
 #endif
@@ -86,11 +68,11 @@ namespace net.r_eg.vsCE
         /// <param name="evt">Supported public events, not null.</param>
         private MainToolCommand(IPkg pkg, OleMenuCommandService svc, IEvLevel evt)
         {
-            this.pkg    = pkg ?? throw new ArgumentNullException(nameof(pkg));
-            svc         = svc ?? throw new ArgumentNullException(nameof(svc));
-            apievt      = evt ?? throw new ArgumentNullException(nameof(evt));
+            if(pkg == null) throw new ArgumentNullException(nameof(pkg));
+            if(svc == null) throw new ArgumentNullException(nameof(svc));
+            if(evt == null) throw new ArgumentNullException(nameof(evt));
 
-            MenuCommand _GetMenu(int cmd, EventHandler act) => new MenuCommand
+            static MenuCommand _GetMenu(int cmd, EventHandler act) => new
             (
                 act, new CommandID(GuidList.CMD_MAIN, cmd)
             )
@@ -109,13 +91,13 @@ namespace net.r_eg.vsCE
         {
             try
             {
-                if(UI.Util.focusForm(configFrm)) {
-                    return;
-                }
+                if(UI.Util.focusForm(configFrm)) return;
+
                 configFrm = new UI.WForms.EventsFrm(Bootloader._);
                 configFrm.Show();
             }
-            catch(Exception ex) {
+            catch(Exception ex)
+            {
                 Log.Error($"Failed UI: {ex.Message}");
                 Log.Debug(ex.StackTrace);
             }

--- a/vsCommandEvent/ParamPacker.cs
+++ b/vsCommandEvent/ParamPacker.cs
@@ -1,0 +1,56 @@
+﻿/*!
+ * Copyright (c) 2015  Denis Kuzmin <x-3F@outlook.com> github/3F
+ * Copyright (c) vsCommandEvent contributors https://github.com/3F/vsCommandEvent/graphs/contributors
+ * Licensed under the GNU LGPLv3.
+ * See accompanying LICENSE file or visit https://github.com/3F/vsCommandEvent
+*/
+
+using System;
+using System.Text;
+using net.r_eg.SobaScript;
+
+namespace net.r_eg.vsCE
+{
+    internal static class ParamPacker
+    {
+        /// <param name="input">Paired key=value values</param>
+        /// <returns>{"Key1":123},{"Key2":"val2"},{"Key3":true}</returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        internal static string Pack(params object[] input)
+        {
+            if(input == null || (input.Length & 1) == 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(input));
+            }
+
+            StringBuilder sb = new();
+            for(int i = 0, n = input.Length - 1; true; ++i)
+            {
+                sb.Append($"{{\"{input[i]}\":");
+
+                    object v = input[++i];
+                    if(v is string str)
+                    {
+                        sb.Append($"\"{str}\"");
+                    }
+                    else if(v is bool flag)
+                    {
+                        sb.Append(Value.From(flag));
+                    }
+                    else
+                    {
+                        sb.Append(Value.From(v));
+                    }
+
+                sb.Append('}');
+
+                if(i < n)
+                {
+                    sb.Append(',');
+                }
+                else break;
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/vsCommandEvent/ParamPacker.cs
+++ b/vsCommandEvent/ParamPacker.cs
@@ -52,5 +52,8 @@ namespace net.r_eg.vsCE
             }
             return sb.ToString();
         }
+
+        internal static string PackRect(int left, int top, int width, int height)
+            => $"{left}|{top}|{width}|{height}";
     }
 }

--- a/vsCommandEvent/SobaScript/Components/DteComponent.cs
+++ b/vsCommandEvent/SobaScript/Components/DteComponent.cs
@@ -79,13 +79,13 @@ namespace net.r_eg.vsCE.SobaScript.Components
             object customOut    = Extract(args[3]);
 
             LSender.Send(this, $"{M_RAISE}('{guid}', '{id}', '{customIn}', '{customOut}')");
-            Raise(guid, id, ref customIn, ref customOut);
+            Raise(guid, id, customIn, customOut);
             return Value.Empty;
         }
 
-        protected virtual void Raise(string guid, int id, ref object customIn, ref object customOut)
+        protected virtual void Raise(string guid, int id, object customIn, object customOut)
         {
-            envce.Raise(guid, id, ref customIn, ref customOut);
+            envce.Raise(guid, id, customIn, customOut);
         }
 
         private static object Extract(Argument arg)

--- a/vsCommandEvent/SobaScript/Components/IDteCeEnv.cs
+++ b/vsCommandEvent/SobaScript/Components/IDteCeEnv.cs
@@ -18,6 +18,6 @@ namespace net.r_eg.vsCE.SobaScript.Components
         /// <param name="id">The command ID.</param>
         /// <param name="customIn">Custom input parameters.</param>
         /// <param name="customOut">Custom output parameters.</param>
-        void Raise(string guid, int id, ref object customIn, ref object customOut);
+        void Raise(string guid, int id, object customIn, object customOut);
     }
 }

--- a/vsCommandEvent/UI/EnumDecor.cs
+++ b/vsCommandEvent/UI/EnumDecor.cs
@@ -1,0 +1,26 @@
+﻿/*!
+ * Copyright (c) 2015  Denis Kuzmin <x-3F@outlook.com> github/3F
+ * Copyright (c) vsCommandEvent contributors https://github.com/3F/vsCommandEvent/graphs/contributors
+ * Licensed under the GNU LGPLv3.
+ * See accompanying LICENSE file or visit https://github.com/3F/vsCommandEvent
+*/
+
+namespace net.r_eg.vsCE.UI
+{
+    public static class EnumDecor
+    {
+        private const string VS_CONST = "Microsoft.VisualStudio.VSConstants";
+
+        public static string Shorten(string input)
+        {
+            if(input == null) return null;
+
+            if(input.StartsWith(VS_CONST))
+            {
+                return input.Substring(VS_CONST.Length);
+            }
+
+            return input;
+        }
+    }
+}

--- a/vsCommandEvent/UI/ITransfer.cs
+++ b/vsCommandEvent/UI/ITransfer.cs
@@ -33,11 +33,6 @@ namespace net.r_eg.vsCE.UI
         /// <summary>
         /// EnvDTE command.
         /// </summary>
-        /// <param name="guid"></param>
-        /// <param name="id"></param>
-        /// <param name="customIn"></param>
-        /// <param name="customOut"></param>
-        /// <param name="description"></param>
-        void command(string guid, int id, object customIn, object customOut, string description);
+        void command(bool pre, string guid, int id, object customIn, object customOut, string description);
     }
 }

--- a/vsCommandEvent/UI/Util.cs
+++ b/vsCommandEvent/UI/Util.cs
@@ -108,6 +108,8 @@ namespace net.r_eg.vsCE.UI
                     DataGridViewCellEventHandler call = (sender, e) => { callback(sender, (EventArgs)e); };
                     ((DataGridView)ctrl).CellValueChanged -= call;
                     ((DataGridView)ctrl).CellValueChanged += call;
+                    ((DataGridView)ctrl).CellContentClick -= call;
+                    ((DataGridView)ctrl).CellContentClick += call;
                     continue;
                 }
 

--- a/vsCommandEvent/UI/Util.cs
+++ b/vsCommandEvent/UI/Util.cs
@@ -218,7 +218,7 @@ namespace net.r_eg.vsCE.UI
         /// </summary>
         public static string enumViewBy(string sguid, int id)
         {
-            if(AggregatedEventsEnvDte.ExtraEvents.TryGetValue(sguid, out string found)) {
+            if(AggregatedEventsEnvDte.FindExtra(sguid, out string found)) {
                 return found;
             }
 

--- a/vsCommandEvent/UI/WForms/EnvDteSniffer.Designer.cs
+++ b/vsCommandEvent/UI/WForms/EnvDteSniffer.Designer.cs
@@ -32,6 +32,7 @@
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
             this.chkActivate = new System.Windows.Forms.CheckBox();
             this.groupBoxCESniffer = new System.Windows.Forms.GroupBox();
+            this.chkPin = new System.Windows.Forms.CheckBox();
             this.btnRaise = new System.Windows.Forms.Button();
             this.btnAddToFilters = new System.Windows.Forms.Button();
             this.buttonFlush = new System.Windows.Forms.Button();
@@ -78,6 +79,7 @@
             // 
             // groupBoxCESniffer
             // 
+            this.groupBoxCESniffer.Controls.Add(this.chkPin);
             this.groupBoxCESniffer.Controls.Add(this.btnRaise);
             this.groupBoxCESniffer.Controls.Add(this.btnAddToFilters);
             this.groupBoxCESniffer.Controls.Add(this.buttonFlush);
@@ -89,9 +91,21 @@
             this.groupBoxCESniffer.Margin = new System.Windows.Forms.Padding(0);
             this.groupBoxCESniffer.Name = "groupBoxCESniffer";
             this.groupBoxCESniffer.Padding = new System.Windows.Forms.Padding(0);
-            this.groupBoxCESniffer.Size = new System.Drawing.Size(743, 37);
+            this.groupBoxCESniffer.Size = new System.Drawing.Size(800, 37);
             this.groupBoxCESniffer.TabIndex = 64;
             this.groupBoxCESniffer.TabStop = false;
+            // 
+            // chkPin
+            // 
+            this.chkPin.AutoSize = true;
+            this.chkPin.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
+            this.chkPin.Location = new System.Drawing.Point(335, 14);
+            this.chkPin.Name = "chkPin";
+            this.chkPin.Size = new System.Drawing.Size(36, 17);
+            this.chkPin.TabIndex = 72;
+            this.chkPin.Text = "📌";
+            this.chkPin.UseVisualStyleBackColor = true;
+            this.chkPin.CheckedChanged += new System.EventHandler(this.chkPin_CheckedChanged);
             // 
             // btnRaise
             // 
@@ -146,7 +160,7 @@
             this.panelTop.Location = new System.Drawing.Point(0, 0);
             this.panelTop.Name = "panelTop";
             this.panelTop.Padding = new System.Windows.Forms.Padding(2);
-            this.panelTop.Size = new System.Drawing.Size(747, 41);
+            this.panelTop.Size = new System.Drawing.Size(804, 41);
             this.panelTop.TabIndex = 65;
             // 
             // panelMain
@@ -155,7 +169,7 @@
             this.panelMain.Dock = System.Windows.Forms.DockStyle.Fill;
             this.panelMain.Location = new System.Drawing.Point(0, 41);
             this.panelMain.Name = "panelMain";
-            this.panelMain.Size = new System.Drawing.Size(747, 254);
+            this.panelMain.Size = new System.Drawing.Size(804, 254);
             this.panelMain.TabIndex = 66;
             // 
             // dgvCESniffer
@@ -196,7 +210,7 @@
             this.dgvCESniffer.RowTemplate.DefaultCellStyle.SelectionForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
             this.dgvCESniffer.RowTemplate.Height = 17;
             this.dgvCESniffer.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.dgvCESniffer.Size = new System.Drawing.Size(747, 254);
+            this.dgvCESniffer.Size = new System.Drawing.Size(804, 254);
             this.dgvCESniffer.TabIndex = 7;
             // 
             // dgvCESnifferColumnStamp
@@ -335,7 +349,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(747, 295);
+            this.ClientSize = new System.Drawing.Size(804, 295);
             this.Controls.Add(this.panelMain);
             this.Controls.Add(this.panelTop);
             this.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
@@ -382,5 +396,6 @@
         private System.Windows.Forms.ToolStripMenuItem menuFlush;
         private System.Windows.Forms.Button btnRaise;
         private System.Windows.Forms.ToolStripMenuItem menuRaise;
+        private System.Windows.Forms.CheckBox chkPin;
     }
 }

--- a/vsCommandEvent/UI/WForms/EnvDteSniffer.Designer.cs
+++ b/vsCommandEvent/UI/WForms/EnvDteSniffer.Designer.cs
@@ -47,7 +47,7 @@
             this.dgvCESnifferColumnId = new net.r_eg.vsCE.UI.WForms.Components.DataGridViewExt.NumericColumn();
             this.dgvCESnifferColumnCustomIn = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.dgvCESnifferColumnCustomOut = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dgvCESnifferColumnEnum = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.dgvCESnifferColumnSrc = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.contextMenuMain = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.menuAddToFilters = new System.Windows.Forms.ToolStripMenuItem();
             this.menuRaise = new System.Windows.Forms.ToolStripMenuItem();
@@ -188,7 +188,7 @@
             this.dgvCESnifferColumnId,
             this.dgvCESnifferColumnCustomIn,
             this.dgvCESnifferColumnCustomOut,
-            this.dgvCESnifferColumnEnum});
+            this.dgvCESnifferColumnSrc});
             this.dgvCESniffer.ContextMenuStrip = this.contextMenuMain;
             dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Window;
@@ -278,14 +278,13 @@
             this.dgvCESnifferColumnCustomOut.ToolTipText = "Filter by Custom output parameter";
             this.dgvCESnifferColumnCustomOut.Width = 110;
             // 
-            // dgvCESnifferColumnEnum
+            // dgvCESnifferColumnSrc
             // 
-            this.dgvCESnifferColumnEnum.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.dgvCESnifferColumnEnum.HeaderText = "Enum";
-            this.dgvCESnifferColumnEnum.MinimumWidth = 100;
-            this.dgvCESnifferColumnEnum.Name = "dgvCESnifferColumnEnum";
-            this.dgvCESnifferColumnEnum.ReadOnly = true;
-            this.dgvCESnifferColumnEnum.ToolTipText = "Equivalent with Enum";
+            this.dgvCESnifferColumnSrc.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.dgvCESnifferColumnSrc.HeaderText = "Source";
+            this.dgvCESnifferColumnSrc.MinimumWidth = 100;
+            this.dgvCESnifferColumnSrc.Name = "dgvCESnifferColumnSrc";
+            this.dgvCESnifferColumnSrc.ReadOnly = true;
             // 
             // contextMenuMain
             // 
@@ -380,7 +379,7 @@
         private Components.DataGridViewExt.NumericColumn dgvCESnifferColumnId;
         private System.Windows.Forms.DataGridViewTextBoxColumn dgvCESnifferColumnCustomIn;
         private System.Windows.Forms.DataGridViewTextBoxColumn dgvCESnifferColumnCustomOut;
-        private System.Windows.Forms.DataGridViewTextBoxColumn dgvCESnifferColumnEnum;
+        private System.Windows.Forms.DataGridViewTextBoxColumn dgvCESnifferColumnSrc;
         private Controls.Lights lightsTraffic;
         private System.Windows.Forms.Panel panelTop;
         private System.Windows.Forms.Panel panelMain;

--- a/vsCommandEvent/UI/WForms/EnvDteSniffer.cs
+++ b/vsCommandEvent/UI/WForms/EnvDteSniffer.cs
@@ -165,7 +165,7 @@ namespace net.r_eg.vsCE.UI.WForms
                     id      = Convert.ToInt32(cId);
                     guid    = cGuid.ToString().Trim();
 
-                    env.raise(guid, id, ref customIn, ref customOut);
+                    env.raise(guid, id, customIn, customOut);
                 }
             }
             catch(Exception ex)

--- a/vsCommandEvent/UI/WForms/EnvDteSniffer.cs
+++ b/vsCommandEvent/UI/WForms/EnvDteSniffer.cs
@@ -89,7 +89,16 @@ namespace net.r_eg.vsCE.UI.WForms
             }
 
             string tFormat = System.Globalization.CultureInfo.CurrentCulture.DateTimeFormat.LongTimePattern + " .fff";
-            dgvCESniffer.Rows.Add(DateTime.Now.ToString(tFormat), pre, guid, id, Value.Pack(customIn), Value.Pack(customOut), Util.enumViewBy(guid, id));
+            dgvCESniffer.Rows.Add
+            (
+                DateTime.Now.ToString(tFormat),
+                pre,
+                guid,
+                id,
+                Value.Pack(customIn),
+                Value.Pack(customOut),
+                EnumDecor.Shorten(Util.enumViewBy(guid, id))
+            );
         }
 
         protected void flash(Lights.FlashType type, int delay = 250)
@@ -180,7 +189,7 @@ namespace net.r_eg.vsCE.UI.WForms
                     Convert.ToInt32(rc.Cells[dgvCESnifferColumnId.Name].Value),
                     rc.Cells[dgvCESnifferColumnCustomIn.Name].Value,
                     rc.Cells[dgvCESnifferColumnCustomOut.Name].Value,
-                    (string)rc.Cells[dgvCESnifferColumnEnum.Name].Value
+                    (string)rc.Cells[dgvCESnifferColumnSrc.Name].Value
                 );
             }
         }

--- a/vsCommandEvent/UI/WForms/EnvDteSniffer.cs
+++ b/vsCommandEvent/UI/WForms/EnvDteSniffer.cs
@@ -62,6 +62,8 @@ namespace net.r_eg.vsCE.UI.WForms
 
             InitializeComponent();
             Icon = Resource.Package_32;
+
+            chkPin.Checked = true;
         }
 
         protected void commandEventBefore(string guid, int id, object customIn, object customOut, ref bool cancelDefault)
@@ -171,7 +173,9 @@ namespace net.r_eg.vsCE.UI.WForms
 
             foreach(DataGridViewRow rc in dgvCESniffer.SelectedRows)
             {
-                link.command(
+                link.command
+                (
+                    Convert.ToBoolean(rc.Cells[dgvCESnifferColumnPre.Name].Value),
                     (string)rc.Cells[dgvCESnifferColumnGuid.Name].Value,
                     Convert.ToInt32(rc.Cells[dgvCESnifferColumnId.Name].Value),
                     rc.Cells[dgvCESnifferColumnCustomIn.Name].Value,
@@ -205,5 +209,7 @@ namespace net.r_eg.vsCE.UI.WForms
         private void menuRaise_Click(object sender, EventArgs e) => btnRaise_Click(sender, e);
 
         private void menuFlush_Click(object sender, EventArgs e) => buttonFlush_Click(sender, e);
+
+        private void chkPin_CheckedChanged(object sender, EventArgs e) => TopMost = chkPin.Checked;
     }
 }

--- a/vsCommandEvent/UI/WForms/EventsFrm.Designer.cs
+++ b/vsCommandEvent/UI/WForms/EventsFrm.Designer.cs
@@ -33,8 +33,6 @@
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle5 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle4 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle7 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle6 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle10 = new System.Windows.Forms.DataGridViewCellStyle();
@@ -43,6 +41,8 @@
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle12 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle11 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle13 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle4 = new System.Windows.Forms.DataGridViewCellStyle();
             this.contextMenuActions = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.menuActionsAdd = new System.Windows.Forms.ToolStripMenuItem();
             this.menuActionsClone = new System.Windows.Forms.ToolStripMenuItem();
@@ -108,6 +108,7 @@
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
             this.labelTimeLimit = new System.Windows.Forms.Label();
             this.numericTimeLimit = new System.Windows.Forms.NumericUpDown();
+            this.chkPin = new System.Windows.Forms.CheckBox();
             this.btnApply = new System.Windows.Forms.Button();
             this.splitContainerMain = new System.Windows.Forms.SplitContainer();
             this.linkAddAction = new System.Windows.Forms.LinkLabel();
@@ -117,18 +118,10 @@
             this.dgvActionName = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.dgvActionCaption = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.splitContainerCfg = new System.Windows.Forms.SplitContainer();
+            this.btnSniffer = new System.Windows.Forms.Button();
             this.tabControlCommands = new System.Windows.Forms.TabControl();
             this.tabPageEnvDTE = new System.Windows.Forms.TabPage();
             this.dgvCEFilters = new net.r_eg.vsCE.UI.WForms.Components.DataGridViewExt();
-            this.dgvCEFiltersColumnGuid = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dgvCEFiltersColumnId = new net.r_eg.vsCE.UI.WForms.Components.DataGridViewExt.NumericColumn();
-            this.dgvCEFiltersColumnCustomIn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dgvCEFiltersColumnCustomOut = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dgvCEFiltersColumnDescription = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dgvCEFiltersColumnCancel = new System.Windows.Forms.DataGridViewCheckBoxColumn();
-            this.dgvCEFiltersColumnPre = new System.Windows.Forms.DataGridViewCheckBoxColumn();
-            this.dgvCEFiltersColumnPost = new System.Windows.Forms.DataGridViewCheckBoxColumn();
-            this.dgvCEFiltersColumnRemove = new System.Windows.Forms.DataGridViewButtonColumn();
             this.contextMenuDte = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.menuSniffer = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
@@ -186,6 +179,17 @@
             this.radioModeFiles = new System.Windows.Forms.RadioButton();
             this.panelStatusSide = new System.Windows.Forms.Panel();
             this.dgvOutput = new net.r_eg.vsCE.UI.WForms.Components.DataGridViewExt();
+            this.dgvCEFiltersColumnPre = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+            this.dgvCEFiltersColumnPost = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+            this.dgvCEFiltersColumnGuid = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.dgvCEFiltersColumnId = new net.r_eg.vsCE.UI.WForms.Components.DataGridViewExt.NumericColumn();
+            this.dgvCEFiltersColumnIgnoreCustomIn = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+            this.dgvCEFiltersColumnCustomIn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.dgvCEFiltersColumnIgnoreCustomOut = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+            this.dgvCEFiltersColumnCustomOut = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.dgvCEFiltersColumnDescription = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.dgvCEFiltersColumnCancel = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+            this.dgvCEFiltersColumnRemove = new System.Windows.Forms.DataGridViewButtonColumn();
             this.contextMenuActions.SuspendLayout();
             this.statusStrip.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numericTimeLimit)).BeginInit();
@@ -293,9 +297,9 @@
             this.toolStripMenuHelp,
             this.toolStripMenuBug,
             this.toolStripMenuVersion});
-            this.statusStrip.Location = new System.Drawing.Point(708, 1);
+            this.statusStrip.Location = new System.Drawing.Point(641, 1);
             this.statusStrip.Name = "statusStrip";
-            this.statusStrip.Size = new System.Drawing.Size(158, 22);
+            this.statusStrip.Size = new System.Drawing.Size(225, 22);
             this.statusStrip.SizingGrip = false;
             this.statusStrip.TabIndex = 81;
             // 
@@ -328,7 +332,7 @@
             // 
             this.toolStripMenuApply.Name = "toolStripMenuApply";
             this.toolStripMenuApply.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-            this.toolStripMenuApply.Size = new System.Drawing.Size(185, 22);
+            this.toolStripMenuApply.Size = new System.Drawing.Size(196, 22);
             this.toolStripMenuApply.Text = "Apply";
             this.toolStripMenuApply.Click += new System.EventHandler(this.toolStripMenuApply_Click);
             // 
@@ -336,7 +340,7 @@
             // 
             this.menuActionExec.Name = "menuActionExec";
             this.menuActionExec.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.E)));
-            this.menuActionExec.Size = new System.Drawing.Size(185, 22);
+            this.menuActionExec.Size = new System.Drawing.Size(196, 22);
             this.menuActionExec.Text = "Execute";
             this.menuActionExec.ToolTipText = "Try current action (Common Context)";
             this.menuActionExec.Click += new System.EventHandler(this.menuActionExec_Click);
@@ -345,14 +349,14 @@
             // 
             this.toolStripMenuReset.Name = "toolStripMenuReset";
             this.toolStripMenuReset.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.R)));
-            this.toolStripMenuReset.Size = new System.Drawing.Size(185, 22);
+            this.toolStripMenuReset.Size = new System.Drawing.Size(196, 22);
             this.toolStripMenuReset.Text = "Reset";
             this.toolStripMenuReset.Click += new System.EventHandler(this.toolStripMenuReset_Click);
             // 
             // toolStripSeparator7
             // 
             this.toolStripSeparator7.Name = "toolStripSeparator7";
-            this.toolStripSeparator7.Size = new System.Drawing.Size(182, 6);
+            this.toolStripSeparator7.Size = new System.Drawing.Size(193, 6);
             // 
             // menuConfiguration
             // 
@@ -360,7 +364,7 @@
             this.menuCfgUseSln,
             this.menuCfgClone});
             this.menuConfiguration.Name = "menuConfiguration";
-            this.menuConfiguration.Size = new System.Drawing.Size(185, 22);
+            this.menuConfiguration.Size = new System.Drawing.Size(196, 22);
             this.menuConfiguration.Text = "Configuration";
             // 
             // menuCfgUseSln
@@ -380,7 +384,7 @@
             // toolStripSeparator6
             // 
             this.toolStripSeparator6.Name = "toolStripSeparator6";
-            this.toolStripSeparator6.Size = new System.Drawing.Size(182, 6);
+            this.toolStripSeparator6.Size = new System.Drawing.Size(193, 6);
             // 
             // toolStripMenuTools
             // 
@@ -393,7 +397,7 @@
             this.toolStripMenuDTECmdExec,
             this.menuItemSniffer});
             this.toolStripMenuTools.Name = "toolStripMenuTools";
-            this.toolStripMenuTools.Size = new System.Drawing.Size(185, 22);
+            this.toolStripMenuTools.Size = new System.Drawing.Size(196, 22);
             this.toolStripMenuTools.Text = "Tools";
             // 
             // menuSBEScript
@@ -448,7 +452,7 @@
             this.menuWizards.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.menuWizardVersion});
             this.menuWizards.Name = "menuWizards";
-            this.menuWizards.Size = new System.Drawing.Size(185, 22);
+            this.menuWizards.Size = new System.Drawing.Size(196, 22);
             this.menuWizards.Text = "Wizards";
             // 
             // menuWizardVersion
@@ -461,7 +465,7 @@
             // menuComponents
             // 
             this.menuComponents.Name = "menuComponents";
-            this.menuComponents.Size = new System.Drawing.Size(185, 22);
+            this.menuComponents.Size = new System.Drawing.Size(196, 22);
             this.menuComponents.Text = "Components";
             this.menuComponents.Click += new System.EventHandler(this.menuComponents_Click);
             // 
@@ -471,7 +475,7 @@
             this.menuTplTargets,
             this.menuTplCSharp});
             this.toolStripMenuTpl.Name = "toolStripMenuTpl";
-            this.toolStripMenuTpl.Size = new System.Drawing.Size(185, 22);
+            this.toolStripMenuTpl.Size = new System.Drawing.Size(196, 22);
             this.toolStripMenuTpl.Text = "Templates";
             // 
             // menuTplTargets
@@ -507,7 +511,7 @@
             // toolStripSeparator11
             // 
             this.toolStripSeparator11.Name = "toolStripSeparator11";
-            this.toolStripSeparator11.Size = new System.Drawing.Size(182, 6);
+            this.toolStripSeparator11.Size = new System.Drawing.Size(193, 6);
             // 
             // toolStripMenuPlugin
             // 
@@ -515,27 +519,27 @@
             this.toolStripMenuPluginDir,
             this.menuCommonCfgDir});
             this.toolStripMenuPlugin.Name = "toolStripMenuPlugin";
-            this.toolStripMenuPlugin.Size = new System.Drawing.Size(185, 22);
+            this.toolStripMenuPlugin.Size = new System.Drawing.Size(196, 22);
             this.toolStripMenuPlugin.Text = "Plugin";
             // 
             // toolStripMenuPluginDir
             // 
             this.toolStripMenuPluginDir.Name = "toolStripMenuPluginDir";
-            this.toolStripMenuPluginDir.Size = new System.Drawing.Size(154, 22);
+            this.toolStripMenuPluginDir.Size = new System.Drawing.Size(269, 22);
             this.toolStripMenuPluginDir.Text = "Open plugin directory";
             this.toolStripMenuPluginDir.Click += new System.EventHandler(this.toolStripMenuPluginDir_Click);
             // 
             // menuCommonCfgDir
             // 
             this.menuCommonCfgDir.Name = "menuCommonCfgDir";
-            this.menuCommonCfgDir.Size = new System.Drawing.Size(154, 22);
+            this.menuCommonCfgDir.Size = new System.Drawing.Size(269, 22);
             this.menuCommonCfgDir.Text = "Open directory where common .vsce";
             this.menuCommonCfgDir.Click += new System.EventHandler(this.menuCommonCfgDir_Click);
             // 
             // menuGetVSSBE
             // 
             this.menuGetVSSBE.Name = "menuGetVSSBE";
-            this.menuGetVSSBE.Size = new System.Drawing.Size(185, 22);
+            this.menuGetVSSBE.Size = new System.Drawing.Size(196, 22);
             this.menuGetVSSBE.Text = "+ vsSolutionBuildEvent";
             this.menuGetVSSBE.Click += new System.EventHandler(this.menuGetVSSBE_Click);
             // 
@@ -713,8 +717,8 @@
             // 
             this.toolStripMenuVersion.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
             this.toolStripMenuVersion.Name = "toolStripMenuVersion";
-            this.toolStripMenuVersion.Size = new System.Drawing.Size(45, 17);
-            this.toolStripMenuVersion.Text = "version";
+            this.toolStripMenuVersion.Size = new System.Drawing.Size(112, 17);
+            this.toolStripMenuVersion.Text = "v00.00.00+ddddddd";
             this.toolStripMenuVersion.Click += new System.EventHandler(this.toolStripMenuVersion_Click);
             this.toolStripMenuVersion.MouseLeave += new System.EventHandler(this.toolStripMenuVersion_MouseLeave);
             this.toolStripMenuVersion.MouseHover += new System.EventHandler(this.toolStripMenuVersion_MouseHover);
@@ -756,15 +760,30 @@
             0,
             0});
             // 
+            // chkPin
+            // 
+            this.chkPin.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.chkPin.AutoSize = true;
+            this.chkPin.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
+            this.chkPin.Location = new System.Drawing.Point(519, 4);
+            this.chkPin.Name = "chkPin";
+            this.chkPin.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
+            this.chkPin.Size = new System.Drawing.Size(36, 17);
+            this.chkPin.TabIndex = 48;
+            this.chkPin.Text = "📌";
+            this.toolTip.SetToolTip(this.chkPin, "Pin window");
+            this.chkPin.UseVisualStyleBackColor = true;
+            this.chkPin.CheckedChanged += new System.EventHandler(this.chkPin_CheckedChanged);
+            // 
             // btnApply
             // 
             this.btnApply.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.btnApply.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnApply.Location = new System.Drawing.Point(625, 0);
+            this.btnApply.Location = new System.Drawing.Point(563, 0);
             this.btnApply.Name = "btnApply";
-            this.btnApply.Size = new System.Drawing.Size(75, 24);
+            this.btnApply.Size = new System.Drawing.Size(69, 24);
             this.btnApply.TabIndex = 79;
-            this.btnApply.Text = "Apply";
+            this.btnApply.Text = "Apply 📡";
             this.btnApply.UseVisualStyleBackColor = true;
             this.btnApply.Click += new System.EventHandler(this.btnApply_Click);
             // 
@@ -777,6 +796,7 @@
             // 
             // splitContainerMain.Panel1
             // 
+            this.splitContainerMain.Panel1.Controls.Add(this.chkPin);
             this.splitContainerMain.Panel1.Controls.Add(this.linkAddAction);
             this.splitContainerMain.Panel1.Controls.Add(this.panelSeparator1);
             this.splitContainerMain.Panel1.Controls.Add(this.dgvActions);
@@ -912,6 +932,7 @@
             // 
             // splitContainerCfg.Panel1
             // 
+            this.splitContainerCfg.Panel1.Controls.Add(this.btnSniffer);
             this.splitContainerCfg.Panel1.Controls.Add(this.tabControlCommands);
             // 
             // splitContainerCfg.Panel2
@@ -923,6 +944,18 @@
             this.splitContainerCfg.Size = new System.Drawing.Size(866, 443);
             this.splitContainerCfg.SplitterDistance = 169;
             this.splitContainerCfg.TabIndex = 0;
+            // 
+            // btnSniffer
+            // 
+            this.btnSniffer.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnSniffer.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
+            this.btnSniffer.Location = new System.Drawing.Point(756, 0);
+            this.btnSniffer.Name = "btnSniffer";
+            this.btnSniffer.Size = new System.Drawing.Size(105, 24);
+            this.btnSniffer.TabIndex = 82;
+            this.btnSniffer.Text = "Sniffer 🔍";
+            this.btnSniffer.UseVisualStyleBackColor = true;
+            this.btnSniffer.Click += new System.EventHandler(this.btnSniffer_Click);
             // 
             // tabControlCommands
             // 
@@ -960,14 +993,16 @@
             this.dgvCEFilters.ClipboardCopyMode = System.Windows.Forms.DataGridViewClipboardCopyMode.EnableWithoutHeaderText;
             this.dgvCEFilters.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.dgvCEFilters.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.dgvCEFiltersColumnPre,
+            this.dgvCEFiltersColumnPost,
             this.dgvCEFiltersColumnGuid,
             this.dgvCEFiltersColumnId,
+            this.dgvCEFiltersColumnIgnoreCustomIn,
             this.dgvCEFiltersColumnCustomIn,
+            this.dgvCEFiltersColumnIgnoreCustomOut,
             this.dgvCEFiltersColumnCustomOut,
             this.dgvCEFiltersColumnDescription,
             this.dgvCEFiltersColumnCancel,
-            this.dgvCEFiltersColumnPre,
-            this.dgvCEFiltersColumnPost,
             this.dgvCEFiltersColumnRemove});
             this.dgvCEFilters.ContextMenuStrip = this.contextMenuDte;
             dataGridViewCellStyle5.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
@@ -994,112 +1029,7 @@
             this.dgvCEFilters.Size = new System.Drawing.Size(843, 140);
             this.dgvCEFilters.TabIndex = 7;
             this.dgvCEFilters.CellClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dgvCEFilters_CellClick);
-            // 
-            // dgvCEFiltersColumnGuid
-            // 
-            this.dgvCEFiltersColumnGuid.HeaderText = "Guid";
-            this.dgvCEFiltersColumnGuid.MinimumWidth = 100;
-            this.dgvCEFiltersColumnGuid.Name = "dgvCEFiltersColumnGuid";
-            this.dgvCEFiltersColumnGuid.ToolTipText = "Scope by GUID";
-            this.dgvCEFiltersColumnGuid.Width = 240;
-            // 
-            // dgvCEFiltersColumnId
-            // 
-            this.dgvCEFiltersColumnId.Decimal = false;
-            dataGridViewCellStyle3.NullValue = "0";
-            this.dgvCEFiltersColumnId.DefaultCellStyle = dataGridViewCellStyle3;
-            this.dgvCEFiltersColumnId.HeaderText = "Id";
-            this.dgvCEFiltersColumnId.MinimumWidth = 70;
-            this.dgvCEFiltersColumnId.Name = "dgvCEFiltersColumnId";
-            this.dgvCEFiltersColumnId.Negative = false;
-            this.dgvCEFiltersColumnId.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.dgvCEFiltersColumnId.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.dgvCEFiltersColumnId.ToolTipText = "Command ID";
-            this.dgvCEFiltersColumnId.Width = 70;
-            // 
-            // dgvCEFiltersColumnCustomIn
-            // 
-            this.dgvCEFiltersColumnCustomIn.HeaderText = "CustomIn";
-            this.dgvCEFiltersColumnCustomIn.MinimumWidth = 70;
-            this.dgvCEFiltersColumnCustomIn.Name = "dgvCEFiltersColumnCustomIn";
-            this.dgvCEFiltersColumnCustomIn.ToolTipText = "Filter by Custom input parameter";
-            this.dgvCEFiltersColumnCustomIn.Width = 110;
-            // 
-            // dgvCEFiltersColumnCustomOut
-            // 
-            this.dgvCEFiltersColumnCustomOut.HeaderText = "CustomOut";
-            this.dgvCEFiltersColumnCustomOut.MinimumWidth = 70;
-            this.dgvCEFiltersColumnCustomOut.Name = "dgvCEFiltersColumnCustomOut";
-            this.dgvCEFiltersColumnCustomOut.ToolTipText = "Filter by Custom output parameter";
-            this.dgvCEFiltersColumnCustomOut.Width = 110;
-            // 
-            // dgvCEFiltersColumnDescription
-            // 
-            this.dgvCEFiltersColumnDescription.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.dgvCEFiltersColumnDescription.HeaderText = "Description";
-            this.dgvCEFiltersColumnDescription.MinimumWidth = 40;
-            this.dgvCEFiltersColumnDescription.Name = "dgvCEFiltersColumnDescription";
-            this.dgvCEFiltersColumnDescription.ToolTipText = "About filter";
-            // 
-            // dgvCEFiltersColumnCancel
-            // 
-            this.dgvCEFiltersColumnCancel.FalseValue = "False";
-            this.dgvCEFiltersColumnCancel.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.dgvCEFiltersColumnCancel.HeaderText = "Cancel";
-            this.dgvCEFiltersColumnCancel.IndeterminateValue = "False";
-            this.dgvCEFiltersColumnCancel.MinimumWidth = 48;
-            this.dgvCEFiltersColumnCancel.Name = "dgvCEFiltersColumnCancel";
-            this.dgvCEFiltersColumnCancel.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-            this.dgvCEFiltersColumnCancel.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.dgvCEFiltersColumnCancel.ToolTipText = "Cancel command if it\'s possible";
-            this.dgvCEFiltersColumnCancel.TrueValue = "True";
-            this.dgvCEFiltersColumnCancel.Width = 48;
-            // 
-            // dgvCEFiltersColumnPre
-            // 
-            this.dgvCEFiltersColumnPre.FalseValue = "False";
-            this.dgvCEFiltersColumnPre.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.dgvCEFiltersColumnPre.HeaderText = "Pre";
-            this.dgvCEFiltersColumnPre.IndeterminateValue = "False";
-            this.dgvCEFiltersColumnPre.MinimumWidth = 28;
-            this.dgvCEFiltersColumnPre.Name = "dgvCEFiltersColumnPre";
-            this.dgvCEFiltersColumnPre.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-            this.dgvCEFiltersColumnPre.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.dgvCEFiltersColumnPre.ToolTipText = "Use Before executing command";
-            this.dgvCEFiltersColumnPre.TrueValue = "True";
-            this.dgvCEFiltersColumnPre.Width = 30;
-            // 
-            // dgvCEFiltersColumnPost
-            // 
-            this.dgvCEFiltersColumnPost.FalseValue = "False";
-            this.dgvCEFiltersColumnPost.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.dgvCEFiltersColumnPost.HeaderText = "Post";
-            this.dgvCEFiltersColumnPost.IndeterminateValue = "False";
-            this.dgvCEFiltersColumnPost.MinimumWidth = 30;
-            this.dgvCEFiltersColumnPost.Name = "dgvCEFiltersColumnPost";
-            this.dgvCEFiltersColumnPost.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-            this.dgvCEFiltersColumnPost.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.dgvCEFiltersColumnPost.ToolTipText = "Use After executed command";
-            this.dgvCEFiltersColumnPost.TrueValue = "True";
-            this.dgvCEFiltersColumnPost.Width = 34;
-            // 
-            // dgvCEFiltersColumnRemove
-            // 
-            dataGridViewCellStyle4.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
-            dataGridViewCellStyle4.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle4.ForeColor = System.Drawing.Color.Maroon;
-            dataGridViewCellStyle4.SelectionBackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle4.SelectionForeColor = System.Drawing.Color.Maroon;
-            this.dgvCEFiltersColumnRemove.DefaultCellStyle = dataGridViewCellStyle4;
-            this.dgvCEFiltersColumnRemove.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.dgvCEFiltersColumnRemove.HeaderText = "";
-            this.dgvCEFiltersColumnRemove.MinimumWidth = 16;
-            this.dgvCEFiltersColumnRemove.Name = "dgvCEFiltersColumnRemove";
-            this.dgvCEFiltersColumnRemove.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-            this.dgvCEFiltersColumnRemove.Text = "x";
-            this.dgvCEFiltersColumnRemove.ToolTipText = "Remove this filter";
-            this.dgvCEFiltersColumnRemove.UseColumnTextForButtonValue = true;
-            this.dgvCEFiltersColumnRemove.Width = 16;
+            this.dgvCEFilters.DefaultValuesNeeded += new System.Windows.Forms.DataGridViewRowEventHandler(this.dgvCEFilters_DefaultValuesNeeded);
             // 
             // contextMenuDte
             // 
@@ -1143,7 +1073,7 @@
             this.tabPageOWP.Location = new System.Drawing.Point(4, 25);
             this.tabPageOWP.Margin = new System.Windows.Forms.Padding(0);
             this.tabPageOWP.Name = "tabPageOWP";
-            this.tabPageOWP.Size = new System.Drawing.Size(858, 146);
+            this.tabPageOWP.Size = new System.Drawing.Size(858, 140);
             this.tabPageOWP.TabIndex = 1;
             this.tabPageOWP.Text = "Output window";
             this.tabPageOWP.UseVisualStyleBackColor = true;
@@ -1182,7 +1112,7 @@
             this.dgvOWP.RowTemplate.DefaultCellStyle.SelectionForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
             this.dgvOWP.RowTemplate.Height = 17;
             this.dgvOWP.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.CellSelect;
-            this.dgvOWP.Size = new System.Drawing.Size(858, 146);
+            this.dgvOWP.Size = new System.Drawing.Size(858, 140);
             this.dgvOWP.TabIndex = 7;
             this.dgvOWP.CellClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewOutput_CellClick);
             // 
@@ -1291,7 +1221,7 @@
             this.tabPageEnvCmd.Location = new System.Drawing.Point(4, 22);
             this.tabPageEnvCmd.Margin = new System.Windows.Forms.Padding(0);
             this.tabPageEnvCmd.Name = "tabPageEnvCmd";
-            this.tabPageEnvCmd.Size = new System.Drawing.Size(722, 247);
+            this.tabPageEnvCmd.Size = new System.Drawing.Size(722, 238);
             this.tabPageEnvCmd.TabIndex = 5;
             this.tabPageEnvCmd.Text = "Environment Commands";
             // 
@@ -1331,7 +1261,7 @@
             this.dgvEnvCmd.RowTemplate.DefaultCellStyle.SelectionForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
             this.dgvEnvCmd.RowTemplate.Height = 17;
             this.dgvEnvCmd.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.CellSelect;
-            this.dgvEnvCmd.Size = new System.Drawing.Size(722, 247);
+            this.dgvEnvCmd.Size = new System.Drawing.Size(722, 238);
             this.dgvEnvCmd.TabIndex = 8;
             this.dgvEnvCmd.CellClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dgvEnvCmd_CellClick);
             // 
@@ -1399,7 +1329,7 @@
             this.tabPageOperations.Location = new System.Drawing.Point(4, 22);
             this.tabPageOperations.Margin = new System.Windows.Forms.Padding(0);
             this.tabPageOperations.Name = "tabPageOperations";
-            this.tabPageOperations.Size = new System.Drawing.Size(722, 247);
+            this.tabPageOperations.Size = new System.Drawing.Size(722, 238);
             this.tabPageOperations.TabIndex = 6;
             this.tabPageOperations.Text = "Operations";
             this.tabPageOperations.UseVisualStyleBackColor = true;
@@ -1438,7 +1368,7 @@
             this.dgvOperations.RowTemplate.DefaultCellStyle.SelectionForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
             this.dgvOperations.RowTemplate.Height = 17;
             this.dgvOperations.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.CellSelect;
-            this.dgvOperations.Size = new System.Drawing.Size(722, 247);
+            this.dgvOperations.Size = new System.Drawing.Size(722, 238);
             this.dgvOperations.TabIndex = 9;
             this.dgvOperations.CellClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dgvOperations_CellClick);
             // 
@@ -1495,7 +1425,7 @@
             this.tabPageSettings.Location = new System.Drawing.Point(4, 22);
             this.tabPageSettings.Name = "tabPageSettings";
             this.tabPageSettings.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPageSettings.Size = new System.Drawing.Size(722, 247);
+            this.tabPageSettings.Size = new System.Drawing.Size(722, 238);
             this.tabPageSettings.TabIndex = 1;
             this.tabPageSettings.Text = "Settings";
             this.tabPageSettings.UseVisualStyleBackColor = true;
@@ -1624,7 +1554,7 @@
             this.tabPageCfgInterpreter.Location = new System.Drawing.Point(4, 22);
             this.tabPageCfgInterpreter.Margin = new System.Windows.Forms.Padding(0);
             this.tabPageCfgInterpreter.Name = "tabPageCfgInterpreter";
-            this.tabPageCfgInterpreter.Size = new System.Drawing.Size(722, 247);
+            this.tabPageCfgInterpreter.Size = new System.Drawing.Size(722, 238);
             this.tabPageCfgInterpreter.TabIndex = 2;
             this.tabPageCfgInterpreter.Text = "Interpreter";
             this.tabPageCfgInterpreter.UseVisualStyleBackColor = true;
@@ -1695,7 +1625,7 @@
             this.tabPageCompilerCfg.Location = new System.Drawing.Point(4, 22);
             this.tabPageCompilerCfg.Margin = new System.Windows.Forms.Padding(0);
             this.tabPageCompilerCfg.Name = "tabPageCompilerCfg";
-            this.tabPageCompilerCfg.Size = new System.Drawing.Size(722, 247);
+            this.tabPageCompilerCfg.Size = new System.Drawing.Size(722, 238);
             this.tabPageCompilerCfg.TabIndex = 4;
             this.tabPageCompilerCfg.Text = "Compiler";
             this.tabPageCompilerCfg.UseVisualStyleBackColor = true;
@@ -1707,7 +1637,7 @@
             this.pGridCompilerCfg.Location = new System.Drawing.Point(0, 0);
             this.pGridCompilerCfg.Margin = new System.Windows.Forms.Padding(0);
             this.pGridCompilerCfg.Name = "pGridCompilerCfg";
-            this.pGridCompilerCfg.Size = new System.Drawing.Size(722, 247);
+            this.pGridCompilerCfg.Size = new System.Drawing.Size(722, 238);
             this.pGridCompilerCfg.TabIndex = 0;
             this.pGridCompilerCfg.ToolbarVisible = false;
             // 
@@ -1850,6 +1780,141 @@
             this.dgvOutput.TabIndex = 7;
             this.dgvOutput.CellClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewOutput_CellClick);
             // 
+            // dgvCEFiltersColumnPre
+            // 
+            this.dgvCEFiltersColumnPre.FalseValue = "False";
+            this.dgvCEFiltersColumnPre.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
+            this.dgvCEFiltersColumnPre.HeaderText = "Pre";
+            this.dgvCEFiltersColumnPre.IndeterminateValue = "False";
+            this.dgvCEFiltersColumnPre.MinimumWidth = 28;
+            this.dgvCEFiltersColumnPre.Name = "dgvCEFiltersColumnPre";
+            this.dgvCEFiltersColumnPre.Resizable = System.Windows.Forms.DataGridViewTriState.False;
+            this.dgvCEFiltersColumnPre.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            this.dgvCEFiltersColumnPre.ToolTipText = "Before executing command";
+            this.dgvCEFiltersColumnPre.TrueValue = "True";
+            this.dgvCEFiltersColumnPre.Width = 30;
+            // 
+            // dgvCEFiltersColumnPost
+            // 
+            this.dgvCEFiltersColumnPost.FalseValue = "False";
+            this.dgvCEFiltersColumnPost.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
+            this.dgvCEFiltersColumnPost.HeaderText = "Post";
+            this.dgvCEFiltersColumnPost.IndeterminateValue = "False";
+            this.dgvCEFiltersColumnPost.MinimumWidth = 30;
+            this.dgvCEFiltersColumnPost.Name = "dgvCEFiltersColumnPost";
+            this.dgvCEFiltersColumnPost.Resizable = System.Windows.Forms.DataGridViewTriState.False;
+            this.dgvCEFiltersColumnPost.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            this.dgvCEFiltersColumnPost.ToolTipText = "After executed command";
+            this.dgvCEFiltersColumnPost.TrueValue = "True";
+            this.dgvCEFiltersColumnPost.Width = 34;
+            // 
+            // dgvCEFiltersColumnGuid
+            // 
+            this.dgvCEFiltersColumnGuid.HeaderText = "Guid";
+            this.dgvCEFiltersColumnGuid.MinimumWidth = 100;
+            this.dgvCEFiltersColumnGuid.Name = "dgvCEFiltersColumnGuid";
+            this.dgvCEFiltersColumnGuid.ToolTipText = "Scope by GUID";
+            this.dgvCEFiltersColumnGuid.Width = 240;
+            // 
+            // dgvCEFiltersColumnId
+            // 
+            this.dgvCEFiltersColumnId.Decimal = false;
+            dataGridViewCellStyle3.NullValue = "0";
+            this.dgvCEFiltersColumnId.DefaultCellStyle = dataGridViewCellStyle3;
+            this.dgvCEFiltersColumnId.HeaderText = "Id";
+            this.dgvCEFiltersColumnId.MinimumWidth = 70;
+            this.dgvCEFiltersColumnId.Name = "dgvCEFiltersColumnId";
+            this.dgvCEFiltersColumnId.Negative = false;
+            this.dgvCEFiltersColumnId.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            this.dgvCEFiltersColumnId.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            this.dgvCEFiltersColumnId.ToolTipText = "Command ID";
+            this.dgvCEFiltersColumnId.Width = 70;
+            // 
+            // dgvCEFiltersColumnIgnoreCustomIn
+            // 
+            this.dgvCEFiltersColumnIgnoreCustomIn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCellsExceptHeader;
+            this.dgvCEFiltersColumnIgnoreCustomIn.FalseValue = "False";
+            this.dgvCEFiltersColumnIgnoreCustomIn.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
+            this.dgvCEFiltersColumnIgnoreCustomIn.HeaderText = "";
+            this.dgvCEFiltersColumnIgnoreCustomIn.IndeterminateValue = "False";
+            this.dgvCEFiltersColumnIgnoreCustomIn.MinimumWidth = 16;
+            this.dgvCEFiltersColumnIgnoreCustomIn.Name = "dgvCEFiltersColumnIgnoreCustomIn";
+            this.dgvCEFiltersColumnIgnoreCustomIn.Resizable = System.Windows.Forms.DataGridViewTriState.False;
+            this.dgvCEFiltersColumnIgnoreCustomIn.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            this.dgvCEFiltersColumnIgnoreCustomIn.ToolTipText = "Ignore CustomIn if unchecked";
+            this.dgvCEFiltersColumnIgnoreCustomIn.TrueValue = "True";
+            this.dgvCEFiltersColumnIgnoreCustomIn.Width = 21;
+            // 
+            // dgvCEFiltersColumnCustomIn
+            // 
+            this.dgvCEFiltersColumnCustomIn.HeaderText = "CustomIn";
+            this.dgvCEFiltersColumnCustomIn.MinimumWidth = 70;
+            this.dgvCEFiltersColumnCustomIn.Name = "dgvCEFiltersColumnCustomIn";
+            this.dgvCEFiltersColumnCustomIn.ToolTipText = "Filter by Custom Input parameter";
+            this.dgvCEFiltersColumnCustomIn.Width = 110;
+            // 
+            // dgvCEFiltersColumnIgnoreCustomOut
+            // 
+            this.dgvCEFiltersColumnIgnoreCustomOut.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCellsExceptHeader;
+            this.dgvCEFiltersColumnIgnoreCustomOut.FalseValue = "False";
+            this.dgvCEFiltersColumnIgnoreCustomOut.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
+            this.dgvCEFiltersColumnIgnoreCustomOut.HeaderText = "";
+            this.dgvCEFiltersColumnIgnoreCustomOut.IndeterminateValue = "False";
+            this.dgvCEFiltersColumnIgnoreCustomOut.MinimumWidth = 16;
+            this.dgvCEFiltersColumnIgnoreCustomOut.Name = "dgvCEFiltersColumnIgnoreCustomOut";
+            this.dgvCEFiltersColumnIgnoreCustomOut.Resizable = System.Windows.Forms.DataGridViewTriState.False;
+            this.dgvCEFiltersColumnIgnoreCustomOut.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            this.dgvCEFiltersColumnIgnoreCustomOut.ToolTipText = "Ignore CustomOut if unchecked";
+            this.dgvCEFiltersColumnIgnoreCustomOut.TrueValue = "True";
+            this.dgvCEFiltersColumnIgnoreCustomOut.Width = 21;
+            // 
+            // dgvCEFiltersColumnCustomOut
+            // 
+            this.dgvCEFiltersColumnCustomOut.HeaderText = "CustomOut";
+            this.dgvCEFiltersColumnCustomOut.MinimumWidth = 70;
+            this.dgvCEFiltersColumnCustomOut.Name = "dgvCEFiltersColumnCustomOut";
+            this.dgvCEFiltersColumnCustomOut.ToolTipText = "Filter by Custom Output parameter";
+            this.dgvCEFiltersColumnCustomOut.Width = 110;
+            // 
+            // dgvCEFiltersColumnDescription
+            // 
+            this.dgvCEFiltersColumnDescription.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.dgvCEFiltersColumnDescription.HeaderText = "Description";
+            this.dgvCEFiltersColumnDescription.MinimumWidth = 40;
+            this.dgvCEFiltersColumnDescription.Name = "dgvCEFiltersColumnDescription";
+            // 
+            // dgvCEFiltersColumnCancel
+            // 
+            this.dgvCEFiltersColumnCancel.FalseValue = "False";
+            this.dgvCEFiltersColumnCancel.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
+            this.dgvCEFiltersColumnCancel.HeaderText = "Cancel";
+            this.dgvCEFiltersColumnCancel.IndeterminateValue = "False";
+            this.dgvCEFiltersColumnCancel.MinimumWidth = 48;
+            this.dgvCEFiltersColumnCancel.Name = "dgvCEFiltersColumnCancel";
+            this.dgvCEFiltersColumnCancel.Resizable = System.Windows.Forms.DataGridViewTriState.False;
+            this.dgvCEFiltersColumnCancel.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            this.dgvCEFiltersColumnCancel.ToolTipText = "Try cancel command if it\'s possible";
+            this.dgvCEFiltersColumnCancel.TrueValue = "True";
+            this.dgvCEFiltersColumnCancel.Width = 48;
+            // 
+            // dgvCEFiltersColumnRemove
+            // 
+            dataGridViewCellStyle4.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            dataGridViewCellStyle4.BackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle4.ForeColor = System.Drawing.Color.Maroon;
+            dataGridViewCellStyle4.SelectionBackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle4.SelectionForeColor = System.Drawing.Color.Maroon;
+            this.dgvCEFiltersColumnRemove.DefaultCellStyle = dataGridViewCellStyle4;
+            this.dgvCEFiltersColumnRemove.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.dgvCEFiltersColumnRemove.HeaderText = "";
+            this.dgvCEFiltersColumnRemove.MinimumWidth = 16;
+            this.dgvCEFiltersColumnRemove.Name = "dgvCEFiltersColumnRemove";
+            this.dgvCEFiltersColumnRemove.Resizable = System.Windows.Forms.DataGridViewTriState.False;
+            this.dgvCEFiltersColumnRemove.Text = "x";
+            this.dgvCEFiltersColumnRemove.ToolTipText = "Remove this line";
+            this.dgvCEFiltersColumnRemove.UseColumnTextForButtonValue = true;
+            this.dgvCEFiltersColumnRemove.Width = 16;
+            // 
             // EventsFrm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -1965,15 +2030,6 @@
         private System.Windows.Forms.PictureBox pictureBoxWarnWait;
         private System.Windows.Forms.ToolTip toolTip;
         private net.r_eg.vsCE.UI.WForms.Components.DataGridViewExt dgvCEFilters;
-        private System.Windows.Forms.DataGridViewTextBoxColumn dgvCEFiltersColumnGuid;
-        private net.r_eg.vsCE.UI.WForms.Components.DataGridViewExt.NumericColumn dgvCEFiltersColumnId;
-        private System.Windows.Forms.DataGridViewTextBoxColumn dgvCEFiltersColumnCustomIn;
-        private System.Windows.Forms.DataGridViewTextBoxColumn dgvCEFiltersColumnCustomOut;
-        private System.Windows.Forms.DataGridViewTextBoxColumn dgvCEFiltersColumnDescription;
-        private System.Windows.Forms.DataGridViewCheckBoxColumn dgvCEFiltersColumnCancel;
-        private System.Windows.Forms.DataGridViewCheckBoxColumn dgvCEFiltersColumnPre;
-        private System.Windows.Forms.DataGridViewCheckBoxColumn dgvCEFiltersColumnPost;
-        private System.Windows.Forms.DataGridViewButtonColumn dgvCEFiltersColumnRemove;
         private System.Windows.Forms.RadioButton radioModeTargets;
         private System.Windows.Forms.RadioButton radioModeCSharp;
         private System.Windows.Forms.PropertyGrid pGridCompilerCfg;
@@ -2050,5 +2106,18 @@
         private System.Windows.Forms.ToolStripMenuItem menuCommonCfgDir;
         private System.Windows.Forms.ToolStripMenuItem menuWizards;
         private System.Windows.Forms.ToolStripMenuItem menuWizardVersion;
+        private System.Windows.Forms.Button btnSniffer;
+        private System.Windows.Forms.CheckBox chkPin;
+        private System.Windows.Forms.DataGridViewCheckBoxColumn dgvCEFiltersColumnPre;
+        private System.Windows.Forms.DataGridViewCheckBoxColumn dgvCEFiltersColumnPost;
+        private System.Windows.Forms.DataGridViewTextBoxColumn dgvCEFiltersColumnGuid;
+        private Components.DataGridViewExt.NumericColumn dgvCEFiltersColumnId;
+        private System.Windows.Forms.DataGridViewCheckBoxColumn dgvCEFiltersColumnIgnoreCustomIn;
+        private System.Windows.Forms.DataGridViewTextBoxColumn dgvCEFiltersColumnCustomIn;
+        private System.Windows.Forms.DataGridViewCheckBoxColumn dgvCEFiltersColumnIgnoreCustomOut;
+        private System.Windows.Forms.DataGridViewTextBoxColumn dgvCEFiltersColumnCustomOut;
+        private System.Windows.Forms.DataGridViewTextBoxColumn dgvCEFiltersColumnDescription;
+        private System.Windows.Forms.DataGridViewCheckBoxColumn dgvCEFiltersColumnCancel;
+        private System.Windows.Forms.DataGridViewButtonColumn dgvCEFiltersColumnRemove;
     }
 }

--- a/vsCommandEvent/UI/WForms/EventsFrm.resx
+++ b/vsCommandEvent/UI/WForms/EventsFrm.resx
@@ -168,7 +168,7 @@
   <data name="panelSeparator1.BackgroundImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAALEAAAABCAYAAACR40+wAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        EAAACxABrSO9dQAAAdlJREFUKFPl0l1LEwAAhWGJoCiIoKCIoKAugoIICoIIChKSrJQwM+zLSEbpdKbN
+        DAAACwwBP0AiyAAAAdlJREFUKFPl0l1LEwAAhWGJoCiIoKCIoKAugoIICoIIChKSrJQwM+zLSEbpdKbN
         yVZL05bZbMpajZxMa7ZJ6lwtp9nUls6mY7XRnFpbLm3lsonW7dvY3+ji/IHnPUl/F2MszkeZn4sQi07z
         KxLi58wkkfAYMyEf4c8evgZcBMecTPocjH+w43f38GmkC++wBc9gO+4BEyN9LQz3NjNk0+F4peXtSw19
         5jp625T0tFZjM1ZhNZTzokmGuVFCh07Mc20RrRohRvVlDHW5PKnNoanmLI2KLBqqTqKtSOeh/CgPZCnU
@@ -188,13 +188,25 @@
   <metadata name="dgvActionCaption.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="dgvCEFiltersColumnPre.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dgvCEFiltersColumnPost.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <metadata name="dgvCEFiltersColumnGuid.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <metadata name="dgvCEFiltersColumnId.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="dgvCEFiltersColumnIgnoreCustomIn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <metadata name="dgvCEFiltersColumnCustomIn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dgvCEFiltersColumnIgnoreCustomOut.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <metadata name="dgvCEFiltersColumnCustomOut.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -204,12 +216,6 @@
     <value>True</value>
   </metadata>
   <metadata name="dgvCEFiltersColumnCancel.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="dgvCEFiltersColumnPre.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="dgvCEFiltersColumnPost.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <metadata name="dgvCEFiltersColumnRemove.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -236,7 +242,7 @@
   <data name="panelSeparator2.BackgroundImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAALEAAAABCAYAAACR40+wAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        EAAACxABrSO9dQAAAdlJREFUKFPl0l1LEwAAhWGJoCiIoKCIoKAugoIICoIIChKSrJQwM+zLSEbpdKbN
+        DAAACwwBP0AiyAAAAdlJREFUKFPl0l1LEwAAhWGJoCiIoKCIoKAugoIICoIIChKSrJQwM+zLSEbpdKbN
         yVZL05bZbMpajZxMa7ZJ6lwtp9nUls6mY7XRnFpbLm3lsonW7dvY3+ji/IHnPUl/F2MszkeZn4sQi07z
         KxLi58wkkfAYMyEf4c8evgZcBMecTPocjH+w43f38GmkC++wBc9gO+4BEyN9LQz3NjNk0+F4peXtSw19
         5jp625T0tFZjM1ZhNZTzokmGuVFCh07Mc20RrRohRvVlDHW5PKnNoanmLI2KLBqqTqKtSOeh/CgPZCnU

--- a/vsCommandEvent/vsCommandEvent.csproj
+++ b/vsCommandEvent/vsCommandEvent.csproj
@@ -178,6 +178,7 @@
     <Compile Include="Configuration\User\UserValue.cs" />
     <Compile Include="DataArgs.cs" />
     <Compile Include="Events\AggregatedEventsEnvDte.cs" />
+    <Compile Include="ParamPacker.cs" />
     <Compile Include="SobaScript\Components\DteComponent.cs" />
     <Compile Include="DteEnv.cs" />
     <Compile Include="DteSlnCfg.cs" />

--- a/vsCommandEvent/vsCommandEvent.csproj
+++ b/vsCommandEvent/vsCommandEvent.csproj
@@ -219,6 +219,7 @@
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
     </Compile>
+    <Compile Include="UI\EnumDecor.cs" />
     <Compile Include="UI\WForms\AboutFrm.cs">
       <SubType>Form</SubType>
     </Compile>


### PR DESCRIPTION
Improves #5 feature and related direction

At a minimum, this adds the ability to disable the CustomIn/Out check in UI

### What does this actually mean?

Now we can compare or manipulate everything through scripts because before it was comparing all received data "as is".

For example, 

```java
#[OWP item("res").writeLine(true):
    #[DTE events.LastCommand.CustomOut]
]
```

> {4, "{8E7B96A8-E33D-11D0-A6D5-00C04FB67F6A}", "CSharp", "StackTest.cs", "D:\tmp\2022\StackFramesApp1\StackFramesApp1", false, true, 4, "Text"}


Actually the result above for something like

```csharp
EnvDTE.Document doc
...
Value.Pack(new object[]
{            
    doc.IndentSize,
    doc.Kind,
    doc.Language,
    doc.Name,
    doc.Path,
    doc.ReadOnly,
    doc.Saved,
    doc.TabSize,
    doc.Type,
});
```

but it is still in progress to have final view